### PR TITLE
Update languages.ts - Add telugu language wikipedia

### DIFF
--- a/frontend/src/languages.ts
+++ b/frontend/src/languages.ts
@@ -145,5 +145,11 @@ export const LANGUAGES = [
     flag: "https://hatscripts.github.io/circle-flags/flags/pk.svg",
     api: "https://ur.wikipedia.org/w/api.php?",
     article: "https://ur.wikipedia.org/wiki/",
+  },
+  {
+    id: "te",
+    name: "Telugu",
+    api: "https://te.wikipedia.org/w/api.php?",
+    article: "https://te.wikipedia.org/wiki/",
   }
 ];


### PR DESCRIPTION
Telugu is one the major languages spoken in India. https://te.wikipedia.org/wiki/%E0%B0%AE%E0%B1%8A%E0%B0%A6%E0%B0%9F%E0%B0%BF_%E0%B0%AA%E0%B1%87%E0%B0%9C%E0%B1%80. I'm not sure which flag to add here, would appreciate some advise here.